### PR TITLE
Critical Path Record

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -120,6 +120,9 @@ JAVA_TOOLS = [
                "//third_party/java/j2objc:embedded_tools_srcs",
                "//third_party/py/abseil:srcs",
                "//third_party/py/concurrent:srcs",
+               # TODO(laszlocsomor): delete "//third_party/py/gflags:srcs" after
+               # every script in @bazel_tools was migrated to use Abseil.
+               "//third_party/py/gflags:srcs",
                "//third_party/py/six:srcs",
                "//src/conditions:embedded_tools",
                "//src/tools/android/java/com/google/devtools/build/android:embedded_tools",

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
@@ -786,16 +786,13 @@ public abstract class BuildEventServiceModule<BESOptionsT extends BuildEventServ
       }
     }
 
-    if (!Strings.isNullOrEmpty(besStreamOptions.criticalPathBuildEventFile)) {
+    if (besStreamOptions.criticalPathBuildEventFile) {
       try {
         BufferedOutputStream bepCriticalPathBuildEventStream =
             new BufferedOutputStream(
-                Files.newOutputStream(Paths.get(besStreamOptions.criticalPathBuildEventFile)));
+                Files.newOutputStream(Paths.get(invocationId)));
 
-        BuildEventArtifactUploader localFileUploader =
-            besStreamOptions.criticalPathBuildEventFilePathConversion
-                ? uploaderSupplier.get()
-                : new LocalFilesArtifactUploader();
+        BuildEventArtifactUploader localFileUploader = new LocalFilesArtifactUploader();
         bepTransportsBuilder.add(
             new CriticalPathBuildEventFileTransport(
                 bepCriticalPathBuildEventStream,
@@ -809,7 +806,7 @@ public abstract class BuildEventServiceModule<BESOptionsT extends BuildEventServ
             reporter,
             cmdEnv.getBlazeModuleEnvironment(),
             "Unable to write to '"
-                + besStreamOptions.criticalPathBuildEventFile
+                + invocationId
                 + "'. Omitting --critical_path_build_event_file.",
             exception,
             ExitCode.LOCAL_ENVIRONMENTAL_ERROR,

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
@@ -44,6 +44,7 @@ import com.google.devtools.build.lib.buildeventstream.transports.BinaryFormatFil
 import com.google.devtools.build.lib.buildeventstream.transports.BuildEventStreamOptions;
 import com.google.devtools.build.lib.buildeventstream.transports.JsonFormatFileTransport;
 import com.google.devtools.build.lib.buildeventstream.transports.TextFormatFileTransport;
+import com.google.devtools.build.lib.buildeventstream.transports.CriticalPathBuildEventFileTransport;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.events.Reporter;
@@ -779,6 +780,38 @@ public abstract class BuildEventServiceModule<BESOptionsT extends BuildEventServ
             "Unable to write to '"
                 + besStreamOptions.buildEventJsonFile
                 + "'. Omitting --build_event_json_file.",
+            exception,
+            ExitCode.LOCAL_ENVIRONMENTAL_ERROR,
+            BuildProgress.Code.BES_LOCAL_WRITE_ERROR);
+      }
+    }
+
+    if (!Strings.isNullOrEmpty(besStreamOptions.criticalPathBuildEventFile)) {
+      reporter.handle(Event.debug(">> Here 0. Try create bepTransportsBuilder"));
+      try {
+        BufferedOutputStream bepCriticalPathBuildEventStream =
+            new BufferedOutputStream(
+                Files.newOutputStream(Paths.get(besStreamOptions.criticalPathBuildEventFile)));
+
+        BuildEventArtifactUploader localFileUploader =
+            besStreamOptions.criticalPathBuildEventFilePathConversion
+                ? uploaderSupplier.get()
+                : new LocalFilesArtifactUploader();
+        bepTransportsBuilder.add(
+            new CriticalPathBuildEventFileTransport(
+                bepCriticalPathBuildEventStream,
+                bepOptions,
+                localFileUploader,
+                artifactGroupNamer));
+      } catch (IOException exception) {
+        // TODO(b/125216340): Consider making this a warning instead of an error once the
+        //  associated bug has been resolved.
+        reportError(
+            reporter,
+            cmdEnv.getBlazeModuleEnvironment(),
+            "Unable to write to '"
+                + besStreamOptions.criticalPathBuildEventFile
+                + "'. Omitting --critical_path_build_event_file.",
             exception,
             ExitCode.LOCAL_ENVIRONMENTAL_ERROR,
             BuildProgress.Code.BES_LOCAL_WRITE_ERROR);

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
@@ -787,7 +787,6 @@ public abstract class BuildEventServiceModule<BESOptionsT extends BuildEventServ
     }
 
     if (!Strings.isNullOrEmpty(besStreamOptions.criticalPathBuildEventFile)) {
-      reporter.handle(Event.debug(">> Here 0. Try create bepTransportsBuilder"));
       try {
         BufferedOutputStream bepCriticalPathBuildEventStream =
             new BufferedOutputStream(

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BuildEventStreamOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BuildEventStreamOptions.java
@@ -64,21 +64,12 @@ public class BuildEventStreamOptions extends OptionsBase {
 
   @Option(
       name = "critical_path_build_event_file",
-      defaultValue = "",
+      defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
-      help = "If non-empty, write a textual representation of the critical path build event protocol to that file.")
-  public String criticalPathBuildEventFile;
-
-  @Option(
-    name = "critical_path_build_event_file_path_conversion",
-    defaultValue = "true",
-    documentationCategory = OptionDocumentationCategory.LOGGING,
-    effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
-    help = "Convert paths in the text file representation of the build event protocol to more "
-        + "globally valid URIs whenever possible; if disabled, the file:// uri scheme will "
-        + "always be used")
-public boolean criticalPathBuildEventFilePathConversion;
+      help = "If non-empty, write a textual representation of the critical path build event "
+            +" to a file name after its invocation id.")
+  public boolean criticalPathBuildEventFile;
 
   @Option(
       name = "build_event_text_file_path_conversion",

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BuildEventStreamOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BuildEventStreamOptions.java
@@ -63,6 +63,24 @@ public class BuildEventStreamOptions extends OptionsBase {
   public String buildEventJsonFile;
 
   @Option(
+      name = "critical_path_build_event_file",
+      defaultValue = "",
+      documentationCategory = OptionDocumentationCategory.LOGGING,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      help = "If non-empty, write a textual representation of the critical path build event protocol to that file.")
+  public String criticalPathBuildEventFile;
+
+  @Option(
+    name = "critical_path_build_event_file_path_conversion",
+    defaultValue = "true",
+    documentationCategory = OptionDocumentationCategory.LOGGING,
+    effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+    help = "Convert paths in the text file representation of the build event protocol to more "
+        + "globally valid URIs whenever possible; if disabled, the file:// uri scheme will "
+        + "always be used")
+public boolean criticalPathBuildEventFilePathConversion;
+
+  @Option(
       name = "build_event_text_file_path_conversion",
       oldName = "experimental_build_event_text_file_path_conversion",
       defaultValue = "true",

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/CriticalPathBuildEventFileTransport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/CriticalPathBuildEventFileTransport.java
@@ -1,0 +1,59 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.buildeventstream.transports;
+
+import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEvent;
+import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId;
+import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildToolLogs;
+import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.File;
+import com.google.common.base.Charsets;
+import com.google.devtools.build.lib.buildeventstream.ArtifactGroupNamer;
+import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
+import com.google.devtools.build.lib.buildeventstream.BuildEventProtocolOptions;
+import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
+import com.google.devtools.build.lib.buildeventstream.BuildEventTransport;
+import com.google.protobuf.TextFormat;
+import java.io.BufferedOutputStream;
+
+
+/**
+ * A simple {@link BuildEventTransport} that writes the text representation of the protocol-buffer
+ * representation of the critical path events to a file.
+ */
+public final class CriticalPathBuildEventFileTransport extends FileTransport {
+  public CriticalPathBuildEventFileTransport(
+      BufferedOutputStream outputStream,
+      BuildEventProtocolOptions options,
+      BuildEventArtifactUploader uploader,
+      ArtifactGroupNamer namer) {
+    super(outputStream, options, uploader, namer);
+  }
+
+  @Override
+  public String name() {
+    return this.getClass().getSimpleName();
+  }
+
+  @Override
+  protected byte[] serializeEvent(BuildEventStreamProtos.BuildEvent buildEvent) {
+    if (buildEvent.hasBuildToolLogs()){
+      BuildToolLogs build_tool_logs = buildEvent.getBuildToolLogs();
+      String elapsed_time = build_tool_logs.getLog(0).getContents().toStringUtf8();
+      String critical_path = build_tool_logs.getLog(1).getContents().toStringUtf8();
+      return ("Elapsed time: " + elapsed_time + "s\n" + critical_path).getBytes(Charsets.UTF_8);
+    }
+    return "".getBytes(Charsets.UTF_8);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/blackbox/bazel/PythonToolsSetup.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/bazel/PythonToolsSetup.java
@@ -16,11 +16,18 @@ package com.google.devtools.build.lib.blackbox.bazel;
 
 import com.google.devtools.build.lib.blackbox.framework.BlackBoxTestContext;
 import com.google.devtools.build.lib.blackbox.framework.ToolsSetup;
+import java.io.IOException;
 
 /** Setup for Bazel Python tools */
 public class PythonToolsSetup implements ToolsSetup {
   @Override
-  public void setup(BlackBoxTestContext context) {
-    // nothing needed to be done
+  public void setup(BlackBoxTestContext context) throws IOException {
+    context.write(
+        "third_party/py/gflags/build",
+        "licenses([\"notice\"])"
+            + "package(default_visibility = [\"//visibility:public\"])"
+            + "py_library("
+            + "    name = \"gflags\","
+            + ")");
   }
 }

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -139,6 +139,16 @@ EOF
   cp -R ${langtools_dir}/* third_party/java/jdk/langtools
 
   chmod -R +w .
+
+  mkdir -p third_party/py/gflags
+  cat > third_party/py/gflags/BUILD <<EOF
+licenses(["notice"])
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "gflags",
+)
+EOF
 }
 
 # Report whether a given directory name corresponds to a tools directory.


### PR DESCRIPTION
Add a flag recording critical path information. If set, write a textual representation of the critical path build event to a file name after its invocation id.
![image](https://user-images.githubusercontent.com/31721073/88411809-6c57d600-cd8d-11ea-8da1-95bf816175ec.png)